### PR TITLE
wrap all ImageLoaders

### DIFF
--- a/Rhapso/split_dataset/save_xml.py
+++ b/Rhapso/split_dataset/save_xml.py
@@ -342,7 +342,6 @@ class SaveXML:
         wrapper.append(base_loader)
         for other_loader in other_imageloaders:
             wrapper.append(other_loader)
-            print("Added multiple ImageLoader sources to split.viewerimgloader wrapper.")
 
         # Inner <SequenceDescription> that holds the original ViewSetups/Timepoints/MissingViews
         inner_seq = ET.Element('SequenceDescription')


### PR DESCRIPTION
#119 

## Description of the changes you made

Wrap all ImageLoaders with the new wrapper "<ImageLoader format="split.viewerimgloader">" element, not just the first.

Example output before:
<img width="502" height="310" alt="Screenshot 2025-12-18 at 10 56 54 AM" src="https://github.com/user-attachments/assets/38690d6f-5b8c-4525-b687-46d278749bf8" />

Example output after:
<img width="487" height="311" alt="Screenshot 2025-12-18 at 10 55 37 AM" src="https://github.com/user-attachments/assets/bd524a4d-3cab-4088-8672-c057efe135d2" />


### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Tested by running the SplitDataset ray pipeline with an input xml which had two ImageLoader data sources.

## Checklist of Requirements

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added unit tests
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

<!-- PLEASE NOTE WHY IF ANY OF THESE CHECKLIST ITEMS HAVE BEEN OMITTED -->

## Instructions for Testing 

<!-- HOW THE REVIEWER SHOULD GO ABOUT TESTING -->

## List dependencies, related tickets, or tasks

<!-- LINKS, TODO's, ANY PR's, CHANGES, ETC. THAT NEED TO BE MERGED PRIOR TO THIS PR  -->

## Additional screenshots or context 

<!-- WHAT ELSE SHOULD WE KNOW ABOUT THIS -->
